### PR TITLE
Fix url of git repository in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/Viglino/font-gis",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Viglino/font-git.git"
+    "url": "git+https://github.com/Viglino/font-gis.git"
   },
   "license": "Apache-2.0",
   "devDependencies": {


### PR DESCRIPTION
Using license-report on one of my projects to list its various dependencies, their licenses and their Git repositories, I noticed that there was a typo in the Git repository URL of your package.

